### PR TITLE
Add JS syntax highlighting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,46 +8,49 @@ Harness RethinkDB Callbacks with ECMAScript 6 Generators
     $ npm install rethinkdb-co
 
 ## Example
+```javascript
+var rco = require('rethinkdb-co');
+var r   = require('rethinkdb');
+var co  = require('co');
 
-    var rco = require('rethinkdb-co');
-    var r   = require('rethinkdb');
-    var co  = require('co');
+var query = r.tableList();
 
-    var query = r.tableList();
-
-    co(function *() {
-      // pause and wait for connection
-      var connection = yield rco.connect();
-      // pause and wait for result
-      var result = yield rco.run(query);
-      console.log('result', result);
-      // disconnect
-      yield rco.disconnect();
-    })();
+co(function *() {
+  // pause and wait for connection
+  var connection = yield rco.connect();
+  // pause and wait for result
+  var result = yield rco.run(query);
+  console.log('result', result);
+  // disconnect
+  yield rco.disconnect();
+})();
+```
 
 ## With koa-rethinkdb
 
-    var rethinkdbPool = require('koa-rethinkdb');
-    var rco           = require('rethinkdb-co');
-    var r             = require('rethinkdb');
+```javascript
+var rethinkdbPool = require('koa-rethinkdb');
+var rco           = require('rethinkdb-co');
+var r             = require('rethinkdb');
 
-    app.use(rethinkdbPool(options));
+app.use(rethinkdbPool(options));
 
-    app.use(function *(next) {
+app.use(function *(next) {
 
-        // get the list of table
-        var query1 = r.db('test').tableList();
+    // get the list of table
+    var query1 = r.db('test').tableList();
 
-        var list = yield rco.run(query1);
+    var list = yield rco.run(query1);
 
-        // select a few documents
-        var query2 = r.db('test').table('foobar').limit(10);
+    // select a few documents
+    var query2 = r.db('test').table('foobar').limit(10);
 
-        result = yield rco.runf(query2);
+    result = yield rco.runf(query2);
 
-        yield next;
-        // connections are released back to the pool.
-    });
+    yield next;
+    // connections are released back to the pool.
+});
+````
 
 ## methond: run
 


### PR DESCRIPTION
A very small addition to the README.md, simply used the syntax for highlighting JavaScript in Markdown,
